### PR TITLE
Passing labels to text_decoder to compute loss.

### DIFF
--- a/src/uform/gen_model.py
+++ b/src/uform/gen_model.py
@@ -265,6 +265,7 @@ class VLMForCausalLM(VLMPreTrainedModel):
             inputs_embeds=inputs_embeds,
             input_ids=input_ids if past_key_values is not None else None,
             attention_mask=attention_mask,
+            labels=labels,
             position_ids=position_ids,
             past_key_values=past_key_values,
             output_attentions=output_attentions,


### PR DESCRIPTION
I noticed, that labels variable is not passed to text_decoder in VLMForCausalLM.forward(). So text_decoder will return just logits and will not compute loss. This makes impossible to use VLMForCausalLM model with transformer.Trainer and requires to write custom train loop or wrap VLMForCausalLM.

There is a fix to avoid that incompatibility.